### PR TITLE
Altair examples

### DIFF
--- a/render.py
+++ b/render.py
@@ -24,6 +24,7 @@ packages = {
     "bokeh": "Bokeh",
     "plotly": "plotly",
     "ggplot": "ggplot2 (R)",
+    "altair": "Altair",
 }
 
 names = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ statsmodels==0.10.0rc2 --pre
 rpy2
 tzlocal
 simplegeneric
+altair

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,26 +1,68 @@
 import render
 
-defined_plots = {'bar-counts': ['pandas', 'plotnine', 'ggplot', 'plotly', ],
-                 'dodged-bar-chart': ['pandas', 'plotnine', 'ggplot', 'plotly', ],
-                 'scatter-plot': ['pandas', 'plotnine', 'ggplot', 'plotly', ],
-                 'scatter-plot-with-colors': ['matplotlib',
-                                              'seaborn',
-                                              'plotnine',
-                                              'ggplot',
-                                              'plotly', ],
-                 'scatter-plot-with-facet': ['seaborn', 'plotnine', 'ggplot', 'plotly', ],
-                 'scatter-plot-with-facets': ['seaborn', 'plotnine', 'ggplot', 'plotly', ],
-                 'scatter-plot-with-size': ['pandas', 'plotnine', 'ggplot', 'plotly', ],
-                 'scatter-with-regression': ['seaborn', 'plotnine', 'ggplot', 'plotly', ],
-                 'simple-histogram': ['pandas', 'matplotlib', 'plotnine', 'ggplot', 'plotly', ],
-                 'stacked-bar-chart': ['pandas', 'plotnine', 'ggplot', 'plotly', ],
-                 'stacked-kde': ['pandas', 'seaborn', 'plotnine', 'ggplot', 'plotly', ],
-                 'stacked-smooth-line-and-scatter': ['plotnine', 'ggplot', 'plotly', ],
-                 'timeseries': ['pandas', 'plotnine', 'ggplot', 'plotly', ]}
+defined_plots = {
+    "bar-counts": ["pandas", "plotnine", "ggplot", "plotly", "altair",],
+    "dodged-bar-chart": ["pandas", "plotnine", "ggplot", "plotly", "altair",],
+    "scatter-plot": ["pandas", "plotnine", "ggplot", "plotly", "altair",],
+    "scatter-plot-with-colors": [
+        "matplotlib",
+        "seaborn",
+        "plotnine",
+        "ggplot",
+        "plotly",
+        "altair",
+    ],
+    "scatter-plot-with-facet": [
+        "seaborn",
+        "plotnine",
+        "ggplot",
+        "plotly",
+        "altair",
+    ],
+    "scatter-plot-with-facets": [
+        "seaborn",
+        "plotnine",
+        "ggplot",
+        "plotly",
+        "altair",
+    ],
+    "scatter-plot-with-size": [
+        "pandas",
+        "plotnine",
+        "ggplot",
+        "plotly",
+        "altair",
+    ],
+    "scatter-with-regression": ["seaborn", "plotnine", "ggplot", "plotly",],
+    "simple-histogram": [
+        "pandas",
+        "matplotlib",
+        "plotnine",
+        "ggplot",
+        "plotly",
+        "altair",
+    ],
+    "stacked-bar-chart": ["pandas", "plotnine", "ggplot", "plotly", "altair",],
+    "stacked-kde": [
+        "pandas",
+        "seaborn",
+        "plotnine",
+        "ggplot",
+        "plotly",
+        "altair",
+    ],
+    "stacked-smooth-line-and-scatter": [
+        "plotnine",
+        "ggplot",
+        "plotly",
+        "altair",
+    ],
+    "timeseries": ["pandas", "plotnine", "ggplot", "plotly", "altair",],
+}
 
 
 def test_exist():
     plots = render.extract_cells("Examples.ipynb")
     for name, slug in plots:
-        names = [d['package-slug'] for d in plots[(name, slug)]]
+        names = [d["package-slug"] for d in plots[(name, slug)]]
         assert set(names) == set(defined_plots[slug])


### PR DESCRIPTION
I've added plotting examples for Altair (4.0, which uses vega3) except for the regression line plot.

I did not try to build this nor run any of the other plotting library examples, so it's possible there is a clash somewhere.

p.s. It looks like the regression example can be achieved with https://github.com/Kitware/seaborn_altair, but I simply skipped it.