### PR TITLE
Add seaborn.objects column to the plotting comparison

### DIFF
--- a/Examples.ipynb
+++ b/Examples.ipynb
@@ -5,7 +5,93 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "%matplotlib inline\n\nimport readline\nimport altair as alt\nimport pandas as pd\nimport seaborn as sns\nfrom matplotlib import pyplot\nfrom plotnine import *\nimport numpy as np\n\nfrom plotly import figure_factory\nfrom plotly import graph_objects\nimport plotly.express as px\nfrom IPython.core.magic import Magics, magics_class, cell_magic\n\nfrom IPython.display import Image\n\nfrom pylab import rcParams\n\nsize = 20\nparams = {\n    \"legend.fontsize\": size,\n    \"figure.figsize\": (15, 5),\n    \"axes.labelsize\": size,\n    \"axes.titlesize\": size,\n    \"xtick.labelsize\": size,\n    \"ytick.labelsize\": size,\n    \"axes.titlesize\": 1.5 * size,\n    \"figure.figsize\": (12, 12),\n}\nrcParams.update(params)\ntheme_update(\n    figure_size=(9, 9),\n    title=element_text(size=size),\n    text=element_text(size=0.6 * size),\n)  # for plotnine\n\n\nimport plotly.io as pio\npio.renderers.default = \"png\"\npio.renderers[\"png\"].width = 750\npio.renderers[\"png\"].height = 750\n\n# Render Altair charts as PNG via vl-convert\nalt.renderers.enable(\"png\", scale_factor=2.0)\n\nimport tempfile\n\nimport lets_plot as lp\nfrom lets_plot.export import ggsave\n\nlp.LetsPlot.setup_html()\nlp.LetsPlot.set_theme(\n    lp.theme(text=lp.element_text(size=16), title=lp.element_text(size=20))\n)\n\n_LETS_PLOT_DIR = tempfile.mkdtemp(prefix=\"lets-plot-\")\n\n\ndef _lets_plot_png(plot):\n    \"\"\"Render a Lets-Plot spec to PNG so the cell output carries an image.\"\"\"\n    path = ggsave(plot + lp.ggsize(750, 750), \"plot.png\", path=_LETS_PLOT_DIR)\n    with open(path, \"rb\") as f:\n        return f.read()\n\n\nget_ipython().display_formatter.formatters[\"image/png\"].for_type(\n    lp.plot.core.PlotSpec, _lets_plot_png\n)"
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "import readline\n",
+    "import altair as alt\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "from matplotlib import pyplot\n",
+    "from plotnine import *\n",
+    "import numpy as np\n",
+    "\n",
+    "from plotly import figure_factory\n",
+    "from plotly import graph_objects\n",
+    "import plotly.express as px\n",
+    "from IPython.core.magic import Magics, magics_class, cell_magic\n",
+    "\n",
+    "from IPython.display import Image\n",
+    "\n",
+    "from pylab import rcParams\n",
+    "\n",
+    "size = 20\n",
+    "params = {\n",
+    "    \"legend.fontsize\": size,\n",
+    "    \"figure.figsize\": (15, 5),\n",
+    "    \"axes.labelsize\": size,\n",
+    "    \"axes.titlesize\": size,\n",
+    "    \"xtick.labelsize\": size,\n",
+    "    \"ytick.labelsize\": size,\n",
+    "    \"axes.titlesize\": 1.5 * size,\n",
+    "    \"figure.figsize\": (12, 12),\n",
+    "}\n",
+    "rcParams.update(params)\n",
+    "theme_update(\n",
+    "    figure_size=(9, 9),\n",
+    "    title=element_text(size=size),\n",
+    "    text=element_text(size=0.6 * size),\n",
+    ")  # for plotnine\n",
+    "\n",
+    "\n",
+    "import seaborn.objects as so\n",
+    "\n",
+    "# Match the other libraries: ~750x750 px output with scaled-up text\n",
+    "so.Plot.config.display[\"scaling\"] = 1\n",
+    "so.Plot.config.theme.update(\n",
+    "    {\n",
+    "        \"figure.figsize\": (8, 8),\n",
+    "        \"axes.labelsize\": size,\n",
+    "        \"axes.titlesize\": 1.5 * size,\n",
+    "        \"xtick.labelsize\": size,\n",
+    "        \"ytick.labelsize\": size,\n",
+    "        \"legend.fontsize\": size,\n",
+    "        \"legend.title_fontsize\": size,\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "import plotly.io as pio\n",
+    "pio.renderers.default = \"png\"\n",
+    "pio.renderers[\"png\"].width = 750\n",
+    "pio.renderers[\"png\"].height = 750\n",
+    "\n",
+    "# Render Altair charts as PNG via vl-convert\n",
+    "alt.renderers.enable(\"png\", scale_factor=2.0)\n",
+    "\n",
+    "import tempfile\n",
+    "\n",
+    "import lets_plot as lp\n",
+    "from lets_plot.export import ggsave\n",
+    "\n",
+    "lp.LetsPlot.setup_html()\n",
+    "lp.LetsPlot.set_theme(\n",
+    "    lp.theme(text=lp.element_text(size=16), title=lp.element_text(size=20))\n",
+    ")\n",
+    "\n",
+    "_LETS_PLOT_DIR = tempfile.mkdtemp(prefix=\"lets-plot-\")\n",
+    "\n",
+    "\n",
+    "def _lets_plot_png(plot):\n",
+    "    \"\"\"Render a Lets-Plot spec to PNG so the cell output carries an image.\"\"\"\n",
+    "    path = ggsave(plot + lp.ggsize(750, 750), \"plot.png\", path=_LETS_PLOT_DIR)\n",
+    "    with open(path, \"rb\") as f:\n",
+    "        return f.read()\n",
+    "\n",
+    "\n",
+    "get_ipython().display_formatter.formatters[\"image/png\"].for_type(\n",
+    "    lp.plot.core.PlotSpec, _lets_plot_png\n",
+    ")"
+   ]
   },
   {
    "cell_type": "code",
@@ -292,6 +378,26 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
+     "name:bar-counts",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"seaborn.objects has no `coord_flip`, so the\n",
+    "categorical variable is mapped to `y` instead.\n",
+    "\"\"\"\n",
+    "(so.Plot(mpg, y=\"manufacturer\")\n",
+    " .add(so.Bar(), so.Count())\n",
+    " .label(title=\"Number of Cars by Make\"))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -421,6 +527,22 @@
     "        y=\"count()\",\n",
     "    )\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
+     "name:simple-histogram",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "(so.Plot(mpg, x=\"cty\")\n",
+    " .add(so.Bars(), so.Hist(binwidth=2)))"
    ]
   },
   {
@@ -556,6 +678,26 @@
     "       displ='Engine Displacement in Liters', \n",
     "       hwy='Highway MPG')\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
+     "name:scatter-plot",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "(so.Plot(mpg, x=\"displ\", y=\"hwy\")\n",
+    " .add(so.Dot())\n",
+    " .label(\n",
+    "    x=\"Engine Displacement in Liters\",\n",
+    "    y=\"Highway MPG\",\n",
+    "    title=\"Engine Displacement in Liters vs Highway MPG\"))"
    ]
   },
   {
@@ -826,6 +968,27 @@
     "tags": [
      "ex",
      "name:scatter-plot-with-colors",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "(so.Plot(mpg, x=\"displ\", y=\"hwy\",\n",
+    "         color=\"class\")\n",
+    " .add(so.Dot())\n",
+    " .label(\n",
+    "    x=\"Engine Displacement in Liters\",\n",
+    "    y=\"Highway MPG\",\n",
+    "    title=\"Engine Displacement in Liters vs Highway MPG\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
+     "name:scatter-plot-with-colors",
      "package:plotnine"
     ]
    },
@@ -1018,6 +1181,25 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
+     "name:scatter-plot-with-size",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "(so.Plot(mpg, x=\"cty\", y=\"hwy\",\n",
+    "         pointsize=\"cyl\")\n",
+    " .add(so.Dots(alpha=.5))\n",
+    " .scale(pointsize=(4, 12))\n",
+    " .label(x=\"City MPG\", y=\"Highway MPG\"))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1083,6 +1265,23 @@
     " .map(pyplot.scatter, \"displ\", \"hwy\", s=20)\n",
     " .fig.subplots_adjust(wspace=.2, hspace=.2)\n",
     ");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
+     "name:scatter-plot-with-facet",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "(so.Plot(mpg, x=\"displ\", y=\"hwy\")\n",
+    " .add(so.Dot())\n",
+    " .facet(\"class\", wrap=4))"
    ]
   },
   {
@@ -1209,6 +1408,23 @@
     " .map(pyplot.scatter, \"displ\", \"hwy\", s=20)\n",
     " .fig.subplots_adjust(wspace=.02, hspace=.02)\n",
     ");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
+     "name:scatter-plot-with-facets",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "(so.Plot(mpg, x=\"displ\", y=\"hwy\")\n",
+    " .add(so.Dot())\n",
+    " .facet(col=\"cyl\", row=\"drv\"))"
    ]
   },
   {
@@ -1552,6 +1768,22 @@
    "metadata": {
     "tags": [
      "ex",
+     "name:stacked-bar-chart",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "(so.Plot(diamonds, x=\"cut\", color=\"clarity\")\n",
+    " .add(so.Bar(), so.Count(), so.Stack()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
      "name:dodged-bar-chart",
      "package:ggplot"
     ]
@@ -1665,6 +1897,22 @@
    "metadata": {
     "tags": [
      "ex",
+     "name:dodged-bar-chart",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "(so.Plot(diamonds, x=\"cut\", color=\"clarity\")\n",
+    " .add(so.Bar(), so.Count(), so.Dodge()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
      "name:stacked-kde",
      "package:ggplot"
     ]
@@ -1714,6 +1962,27 @@
    },
    "outputs": [],
    "source": "(sns\n  .FacetGrid(diamonds, \n             hue=\"cut\", \n             height=10, \n             xlim=(55, 70))\n  .map(sns.kdeplot, 'depth', fill=True)\n .add_legend()\n);"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
+     "name:stacked-kde",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"`.limit()` only clips the axis; unlike ggplot2's\n",
+    "`xlim()` it does not drop rows before the density is\n",
+    "estimated.\n",
+    "\"\"\"\n",
+    "(so.Plot(diamonds, x=\"depth\", color=\"cut\")\n",
+    " .add(so.Area(alpha=.1), so.KDE(gridsize=500))\n",
+    " .limit(x=(55, 70)))"
+   ]
   },
   {
    "cell_type": "code",
@@ -1900,6 +2169,22 @@
     "alt.Chart(ts).mark_line().encode(\n",
     "    x=\"date\", y=\"value\"\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "ex",
+     "name:timeseries",
+     "package:seaborn-objects"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "(so.Plot(ts, x=\"date\", y=\"value\")\n",
+    " .add(so.Line()))"
    ]
   }
  ],

--- a/INTRO.md
+++ b/INTRO.md
@@ -20,6 +20,8 @@ Many excellent plotting tools are built on top of Matplotlib.
 
 "[Seaborn](https://seaborn.pydata.org/ "Seaborn: statistical data visualization") is a Python visualization library based on matplotlib. It provides a high-level interface for drawing attractive statistical graphics." Seaborn makes beautiful plots but is geared toward specific statistical plots, not general purpose plotting. It does have a powerful [faceting utility function](http://seaborn.pydata.org/tutorial/axis_grids.html) that I use regularly.
 
+Seaborn 0.12 added [seaborn.objects](https://seaborn.pydata.org/tutorial/objects_interface.html), a second interface built on the grammar of graphics. It composes a plot from marks and statistical transforms instead of dispatching to a named plotting function, so it covers far more of the examples below than the classic interface does. It has no loess smoother and no regression confidence band, so those two examples are missing.
+
 #### Interactive Plotting Libraries
 
 There are several tools that can make the kinds of plots described here. At present, I have little experience with them. If anyone would like to help add examples, please [get in touch](https://github.com/tdhopper/pythonplot.com).

--- a/render.py
+++ b/render.py
@@ -20,6 +20,7 @@ packages = {
     "pandas": "Pandas",
     "matplotlib": "Matplotlib",
     "seaborn": "Seaborn",
+    "seaborn-objects": "seaborn.objects",
     "plotnine": "plotnine",
     "lets-plot": "lets-plot",
     "plotly": "plotly",

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -3,17 +3,18 @@ from collections import defaultdict
 
 defined_plots = {
     "bar-counts": [
-        "pandas", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
+        "pandas", "seaborn-objects", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
     ],
     "dodged-bar-chart": [
-        "pandas", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
+        "pandas", "seaborn-objects", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
     ],
     "scatter-plot": [
-        "pandas", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
+        "pandas", "seaborn-objects", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
     ],
     "scatter-plot-with-colors": [
         "matplotlib",
         "seaborn",
+        "seaborn-objects",
         "plotnine",
         "lets-plot",
         "ggplot",
@@ -21,13 +22,13 @@ defined_plots = {
         "altair",
     ],
     "scatter-plot-with-facet": [
-        "seaborn", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
+        "seaborn", "seaborn-objects", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
     ],
     "scatter-plot-with-facets": [
-        "seaborn", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
+        "seaborn", "seaborn-objects", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
     ],
     "scatter-plot-with-size": [
-        "pandas", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
+        "pandas", "seaborn-objects", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
     ],
     "scatter-with-regression": [
         "seaborn", "plotnine", "lets-plot", "ggplot", "plotly",
@@ -35,6 +36,7 @@ defined_plots = {
     "simple-histogram": [
         "pandas",
         "matplotlib",
+        "seaborn-objects",
         "plotnine",
         "lets-plot",
         "ggplot",
@@ -42,16 +44,23 @@ defined_plots = {
         "altair",
     ],
     "stacked-bar-chart": [
-        "pandas", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
+        "pandas", "seaborn-objects", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
     ],
     "stacked-kde": [
-        "pandas", "seaborn", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
+        "pandas",
+        "seaborn",
+        "seaborn-objects",
+        "plotnine",
+        "lets-plot",
+        "ggplot",
+        "plotly",
+        "altair",
     ],
     "stacked-smooth-line-and-scatter": [
         "plotnine", "lets-plot", "ggplot", "plotly", "altair",
     ],
     "timeseries": [
-        "pandas", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
+        "pandas", "seaborn-objects", "plotnine", "lets-plot", "ggplot", "plotly", "altair",
     ],
 }
 


### PR DESCRIPTION
## TL;DR

seaborn.objects (`import seaborn.objects as so`) joins the comparison as its own column: 11 of the 13 plots, bringing the total to 90 example cells. Two plots are deliberately absent — the interface has no confidence-band stat for `scatter-with-regression` and no loess smoother for `stacked-smooth-line-and-scatter` — because a lookalike without the CI band or true smoothing would misrepresent the comparison.

Stacked on #24 (`add-lets-plot`).

**Files to review (5, notebook-dominated):**

| File | Why |
|---|---|
| `Examples.ipynb` *(start here)* | 11 new cells tagged `package:seaborn-objects` plus setup-cell config. |
| `render.py` | One line: column ordered right after classic seaborn. |
| `tests/test_plots.py` | `seaborn-objects` added to exactly the 11 implemented slugs. |
| `INTRO.md` | Paragraph introducing the interface. |

## Reviewer notes

- **No export machinery needed**: `so.Plot` emits PNG natively in Jupyter. The setup cell sets `so.Plot.config.display["scaling"] = 1` (the 0.85 default shrinks output) and pushes the notebook's shared figsize/font rcParams into `so.Plot.config.theme`, landing at the same ~750 logical px as the other columns.
- **Two cells carry site-visible caveats**: bar-counts (no `coord_flip`, so manufacturer maps straight to `y`) and stacked-kde (`.limit()` clips the axis but, unlike ggplot2's `xlim()`, doesn't drop rows before density estimation; `gridsize=500` keeps the visible window smooth).
- **Setup-cell diff looks bigger than it is**: the cell's `source` changed from a JSON string to the list-of-lines form the other 99 cells use — valid nbformat, no content implication.

Verified: notebook executes clean, 90/90 example cells emit PNGs, render.py succeeds, pytest passes.
