### PR TITLE
Add weekly scheduled build and Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: ['**']
   pull_request:
     branches: [master]
+  schedule:
+    # Weekly build-health check; deploy steps only run on push events,
+    # so this catches library breakage without touching production.
+    - cron: '0 6 * * 1'
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## TL;DR

The site rotted for six years because nothing ran the build between pushes. A weekly scheduled workflow run now exercises the full pipeline (deploy steps stay push-gated, so production is untouched), and Dependabot files one grouped weekly PR for Python bumps plus monthly GitHub Actions bumps — each proven by CI before merge.
