### PR TITLE
Cut image payload 70% with WebP and lazy loading; add copy buttons and anchors

### DIFF
--- a/render.py
+++ b/render.py
@@ -11,6 +11,8 @@ import logging
 import subprocess
 import base64
 import hashlib
+import io
+from PIL import Image
 
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -49,18 +51,29 @@ with open("INTRO.md", "r") as f:
     intro = f.read()
 
 
+WEBP_QUALITY = 85
+
+
 def image_from_cell(cell):
+    """Save the cell's PNG output as WebP and return its path and pixel size.
+
+    The filename stays the MD5 of the base64 PNG, so a plot that hasn't changed
+    keeps its URL. The pixel size lets the template declare width/height, which
+    reserves layout space for the lazily loaded images.
+    """
     try:
         for c in cell['outputs']:
             if 'data' in c and 'image/png' in c['data']:
                 base64_img = c['data']['image/png'].replace("\n", "").strip()
                 filename = hashlib.md5()
                 filename.update(base64_img.encode('ascii'))
-                web_path = "/img/plots/{}.png".format(filename.hexdigest())
+                web_path = "/img/plots/{}.webp".format(filename.hexdigest())
                 full_path = "web" + web_path
-                with open(full_path, "wb") as fh:
-                    fh.write(base64.b64decode(base64_img))
-                return web_path
+                image = Image.open(io.BytesIO(base64.b64decode(base64_img)))
+                if image.mode not in ("RGB", "RGBA"):
+                    image = image.convert("RGBA")
+                image.save(full_path, "WEBP", quality=WEBP_QUALITY, method=6)
+                return {"path": web_path, "width": image.width, "height": image.height}
     except KeyError as e:
         logging.error("Can't find image in cell: %s", cell['source'])
         raise e
@@ -145,7 +158,9 @@ def extract_cells(path):
             "cell_num": cell_num,
             "package": packages.get(tags["package"], tags["package"]),
             "package-slug": tags['package'],
-            "image": image,
+            "image": image["path"],
+            "image-width": image["width"],
+            "image-height": image["height"],
             "content": source,
             "comment": md.convert(comment) or None,
         })

--- a/templates/t_index.html
+++ b/templates/t_index.html
@@ -135,7 +135,10 @@
                           </a>
                         </div>
                         <div class="col-lg-6 col-xs-12 p-0 right-col d-inline-flex flex-column">
-                          <h6 class="text-muted mb-0 pb-0 pt-3 px-3">Code:</h6>
+                          <div class="code-head d-flex justify-content-between align-items-center pt-3 px-3">
+                            <h6 class="text-muted mb-0 pb-0">Code:</h6>
+                            <button type="button" class="copy-btn" data-copy aria-label="Copy code for {{ name }} with {{ plot['package'] }}">Copy</button>
+                          </div>
                           {% if plot['package'] == "ggplot" %}
                             <code class="p-0 mb-auto">{% highlight 'R' %}{{ plot['content'] }}{% endhighlight %}</code>
                           {% else %}
@@ -181,7 +184,30 @@
           event.preventDefault();
           $(this).ekkoLightbox({alwaysShowClose: true});
       });
-      $.bigfoot();
+    </script>
+
+    <script type="text/javascript">
+      document.addEventListener('click', function (event) {
+        var button = event.target.closest('[data-copy]');
+        if (!button) { return; }
+        var panel = button.closest('.right-col');
+        var code = panel && panel.querySelector('code');
+        if (!code) { return; }
+        var text = code.textContent.replace(/\s+$/, '');
+        var done = function (label) {
+          button.textContent = label;
+          setTimeout(function () { button.textContent = 'Copy'; }, 1500);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(function () {
+            done('Copied');
+          }, function () {
+            done('Press ⌘C');
+          });
+        } else {
+          done('Press ⌘C');
+        }
+      });
     </script>
   </body>
 </html>

--- a/templates/t_index.html
+++ b/templates/t_index.html
@@ -111,7 +111,7 @@
         <section id="{{ slug }}">
           <div class="card mb-4">
             <div class="card-header">
-              <h3 class="card-title mb-1"><a href="#{{ slug }}"><i class="fa fa-link" aria-hidden="true"></i></a> {{ name }}</h3>
+              <h3 class="card-title mb-1">{{ name }}<a class="anchor-link" href="#{{ slug }}" title="Link to {{ name }}" aria-label="Link to {{ name }}">#</a></h3>
               <ul class="nav nav-tabs card-header-tabs">
                 {% for plot in items %}
                 <li class="nav-item">

--- a/templates/t_index.html
+++ b/templates/t_index.html
@@ -4,20 +4,28 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="Interactive comparison of Python plotting libraries for exploratory data analysis. Examples of using Pandas plotting, plotnine, Seaborn, and Matplotlib. Includes comparison with ggplot2 for R.">
+    <meta name="description" content="Side-by-side comparison of Python plotting libraries for exploratory data analysis: pandas, Matplotlib, Seaborn, plotnine, Lets-Plot, plotly, hvPlot, and Altair, with R's ggplot2 for reference.">
     <meta name="author" content="Timothy Hopper">
 
     <title>Python Plotting for Exploratory Analysis</title>
 
+    <link rel="canonical" href="https://pythonplot.com/">
+
     <meta property="og:title" content="Python Plotting for Exploratory Analysis" />
     <meta property="og:type" content="article" />
-    <meta property="og:url" content="https://pythonplot.com" />
-    <meta property="og:image" content="http://pythonplot.com/img/cover.png" />
+    <meta property="og:site_name" content="pythonplot.com" />
+    <meta property="og:url" content="https://pythonplot.com/" />
+    <meta property="og:image" content="https://pythonplot.com/img/banner.png" />
+    <meta property="og:image:alt" content="The same plot drawn with several Python plotting libraries side by side." />
     <meta property="og:description"
-      content="Interactive comparison of Python plotting libraries for exploratory data analysis. Examples of using Pandas plotting, plotnine, Seaborn, and Matplotlib. Includes comparison with ggplot2 for R." />
-    <meta name="twitter:card" content="summary" />
+      content="Side-by-side comparison of Python plotting libraries for exploratory data analysis: pandas, Matplotlib, Seaborn, plotnine, Lets-Plot, plotly, hvPlot, and Altair, with R's ggplot2 for reference." />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@tdhopper" />
     <meta name="twitter:creator" content="@tdhopper" />
+    <meta name="twitter:title" content="Python Plotting for Exploratory Analysis" />
+    <meta name="twitter:description"
+      content="Side-by-side comparison of Python plotting libraries for exploratory data analysis: pandas, Matplotlib, Seaborn, plotnine, Lets-Plot, plotly, hvPlot, and Altair, with R's ggplot2 for reference." />
+    <meta name="twitter:image" content="https://pythonplot.com/img/banner.png" />
 
     <link rel="apple-touch-icon" sizes="57x57" href="/img/ico/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="/img/ico/apple-icon-60x60.png">

--- a/templates/t_index.html
+++ b/templates/t_index.html
@@ -107,6 +107,7 @@
       <hr>
       <div class="row mt-4" id="examples"><div class="col-xs-12 col-md-10 offset-md-1">
         {% for (name, slug), items in plots.items() %}
+        {% set outer_loop = loop %}
         <section id="{{ slug }}">
           <div class="card mb-4">
             <div class="card-header">
@@ -124,12 +125,13 @@
             <div class="card-block p-0">
               <div class="tab-content">
                 {% for plot in items %}
+                  {% set eager = outer_loop.first and loop.first %}
                   <div class="tab-pane  {% if loop.index0 == 0 %} active{% endif %}" id="{{ slug }}{{ plot['package-slug'] }}" role="tabpanel">
                     <div class="container-fluid">
                       <div class="row">
                         <div class="col-lg-6 col-xs-12 p-lg-0">
                           <a href="{{ plot['image'] }}" data-toggle="lightbox" data-title="{{ name }} - {{ plot['package'] }}">
-                            <img src="{{ plot['image'] }}" class="img-fluid">
+                            <img src="{{ plot['image'] }}" class="img-fluid" alt="{{ name }} drawn with {{ plot['package'] }}" width="{{ plot['image-width'] }}" height="{{ plot['image-height'] }}" decoding="async"{% if not eager %} loading="lazy"{% endif %}>
                           </a>
                         </div>
                         <div class="col-lg-6 col-xs-12 p-0 right-col d-inline-flex flex-column">

--- a/web/css/custom.css
+++ b/web/css/custom.css
@@ -27,6 +27,27 @@ table {
     font-family: monospace;
 }
 
+/* Copy button sitting in the dark code panel header. */
+.copy-btn {
+    background: transparent;
+    border: 1px solid #4a4a4a;
+    border-radius: 3px;
+    color: #9a9a9a;
+    cursor: pointer;
+    font-size: .75rem;
+    line-height: 1.2;
+    min-width: 4.5rem;
+    padding: .15rem .5rem;
+    transition: color .15s ease, border-color .15s ease;
+}
+
+.copy-btn:hover,
+.copy-btn:focus {
+    border-color: #7a7a7a;
+    color: #e6e6e6;
+    outline: none;
+}
+
 @media (min-width: 1600px) {
   .container {
     width: 1440px;

--- a/web/css/custom.css
+++ b/web/css/custom.css
@@ -27,6 +27,22 @@ table {
     font-family: monospace;
 }
 
+/* Subtle deep-link anchor next to each plot heading. */
+.anchor-link {
+    color: #adb5bd;
+    font-weight: 400;
+    margin-left: .4rem;
+    opacity: .45;
+    text-decoration: none;
+}
+
+.anchor-link:hover,
+.anchor-link:focus {
+    color: #495057;
+    opacity: 1;
+    text-decoration: none;
+}
+
 /* Copy button sitting in the dark code panel header. */
 .copy-btn {
     background: transparent;


### PR DESCRIPTION
## TL;DR

The page ships 101 plot images; this cuts their payload 70% (8.54 MB → 2.58 MB) by converting render.py's output to WebP q85, and lazy-loads all but the first image with width/height attributes so cards don't reflow while streaming. Also: copy-to-clipboard buttons on every code panel, working anchor links, and fixed social-preview metadata.

Stacked on #26 (`add-hvplot`).

**Files to review (3):**

| File | Why |
|---|---|
| `templates/t_index.html` *(start here)* | lazy/async images with dimensions, copy buttons + inline JS, anchors, OG/twitter/canonical meta. |
| `render.py` | `image_from_cell` writes WebP via Pillow (quality 85); MD5 naming kept so unchanged plots keep URLs. |
| `web/css/custom.css` | `.copy-btn` styling matched to the dark code panel. |

## Reviewer notes

- **Two latent bugs fixed in passing**: the heading anchor used a Font Awesome icon but the site never loads Font Awesome (it rendered as nothing — replaced with a muted `#`), and the template called `$.bigfoot()` with no bigfoot library loaded, throwing a TypeError on every page load. Console is now clean, verified headless.
- **Copy buttons are one delegated listener**, `navigator.clipboard` with a "Press ⌘C" fallback; verified all 101 buttons resolve their code block with zero misses.
- **`og:image` was plain-http** and pointed at a nonexistent cover.png; now https banner.png with alt text and twitter:card.
- Render time grows 0.3 s → 6.8 s from WebP encoding, noise next to the ~4 min notebook execution.
